### PR TITLE
[Bugfix] getParentNode is acquiring another ancestral parent

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -13,11 +13,13 @@ export class Node<T extends Data> {
   hasChildren: boolean;
 
   #treeId: string;
+  #ancestorPath: string;
   #key: string;
   #childKey: string;
 
   constructor({
     treeId,
+    ancestorPath,
     key,
     childKey,
     level,
@@ -26,6 +28,7 @@ export class Node<T extends Data> {
     data,
   }: {
     treeId: string;
+    ancestorPath: string;
     key: string;
     childKey: string;
     level: number;
@@ -43,6 +46,7 @@ export class Node<T extends Data> {
     this.hasChildren = !this.isLeaf;
 
     this.#treeId = treeId;
+    this.#ancestorPath = ancestorPath;
     this.#key = key;
     this.#childKey = childKey;
   }
@@ -91,6 +95,7 @@ export class Node<T extends Data> {
   addChild({ data }: { data: T }): Node<T> {
     const newChildNode = new Node<T>({
       treeId: this.#treeId,
+      ancestorPath: this.#ancestorPath,
       key: this.#key,
       childKey: this.#childKey,
       level: this.level + 1,
@@ -113,7 +118,9 @@ export class Node<T extends Data> {
   getParentNode(): Node<T> | undefined {
     const tree = this.getTree();
     const parentNode = tree.find(
-      (node) => node.data[this.#key] === this.parentKey,
+      (node) =>
+        node.data[this.#key] === this.parentKey &&
+        this.#ancestorPath.includes(node.#ancestorPath),
     );
     return parentNode;
   }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -140,13 +140,21 @@ export class Tree<T extends Data> {
     key,
     childKey,
     nodeParam,
+    ancestorPath,
   }: {
     key: string;
     childKey: string;
     nodeParam: NodeParam<T>;
+    ancestorPath?: string;
   }) {
+    const path =
+      ancestorPath === undefined
+        ? (nodeParam.data[key] as string)
+        : ancestorPath;
+
     const node = new Node<T>({
       treeId: this.treeId,
+      ancestorPath: path,
       key,
       childKey,
       level: nodeParam.level,
@@ -156,6 +164,7 @@ export class Tree<T extends Data> {
           key,
           childKey,
           nodeParam: childNodeModel,
+          ancestorPath: `${path}/${childNodeModel.data[key] as string}`,
         }),
       ),
       data: nodeParam.data,


### PR DESCRIPTION
When retrieving a parent with the getParentNode method, if the hierarchical structure is similar, it is possible to mistakenly retrieve the parent of another ancestor.